### PR TITLE
Fix clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ http://ani-react-theme.meteor.com
 ####1. Clone this project or Download that ZIP file
 
 ```sh
-$ git clone git@github.com:start-react/ani-theme-meteor-react.git
+git clone https://github.com/start-react/ani-theme-meteor-react.git
 ```
 
 ####2.  Make sure you have [meteor](https://www.meteor.com/) installed globally


### PR DESCRIPTION
The current url doesn't work support public download

git clone git@github.com:start-react/ani-theme-meteor-react.git
Cloning into 'ani-theme-meteor-react'...
Permission denied (publickey).
fatal: Could not read from remote repository.
